### PR TITLE
apps/spu-ui: using real plan name in acquisition

### DIFF
--- a/apps/spu-ui/src/lib/schemas/acquisition.ts
+++ b/apps/spu-ui/src/lib/schemas/acquisition.ts
@@ -6,8 +6,7 @@ import {
   trayRows,
 } from "../constants";
 
-// export const planName = "setup1_load_and_acquire";
-export const planName = "load_and_acquire_sim";
+export const planName = "setup1_load_and_acquire";
 
 export const info = {
   sampleType: "Type of the sample to be measured (buffer or sample)",


### PR DESCRIPTION
This is possible if we install a test package for the beamline with simulated test plans with the same name and props as the real plans.
