### PR TITLE
Add support to a list of Literals

### DIFF
--- a/packages/widgets/src/form-components/fields.tsx
+++ b/packages/widgets/src/form-components/fields.tsx
@@ -45,6 +45,7 @@ function definePlaceholder(type: string) {
   }
   return "No information on input type";
 }
+
 function snakeToTitleCase(str: string) {
   return str
     .split("_")
@@ -64,6 +65,27 @@ function InfoTooltip({ children }: { children: React.ReactNode }) {
       <TooltipContent>{children}</TooltipContent>
     </Tooltip>
   );
+}
+
+// this might be useful in other parts too
+function parseLiteralTypes(type: string): string[] {
+  // match Literal[...] inside possibly prefix with regex
+  const literalMatch = type.match(/Literal\[(.*)\]/);
+  if (!literalMatch || !literalMatch[1]) {
+    return [];
+  }
+  const inside = literalMatch[1];
+  // remove extra [ or ] with global tag
+  const cleaned = inside.replace(/\[|\]/g, '');
+  // split with comma and trim and remove only wrapping ' if present
+  return cleaned
+    .split(/\s*,\s*/)
+    .map(opt => {
+      const trimmed = opt.trim();
+      // remove surrounding single or double quotes, if they exist
+      return trimmed.replace(/^'(.*)'$/, '$1').replace(/^"(.*)"$/, '$1');
+    })
+    .filter(opt => opt.length > 0);
 }
 
 interface Devices {
@@ -101,8 +123,13 @@ function AnyField({ devices, param, form }: AnyFieldProps) {
   if (type.includes("bool")) {
     return <BoolField param={param} form={form} type={type} />;
   }
-  if (type.includes("typing.Literal") && !type.includes("list")) {
+  if (type.includes("Literal") && !(type.includes("list") || type.includes("Sequence"))) {
     return <LiteralField param={param} form={form} type={type} />;
+  }
+  if ((type.includes("list") || type.includes("Sequence")) && type.includes("Literal")){
+    return (
+        <MultiLiteralField param={param} form={form} type={type} />
+      );
   }
   if (
     !type.includes("list") &&
@@ -188,10 +215,7 @@ function CallableField({ param, form }: TypedFieldProps) {
 }
 
 function LiteralField({ param, type, form }: TypedFieldProps) {
-  const optionsStr = type.replace("typing.Literal[", "").replace("]", "");
-  const options = optionsStr.split(", ").map((option) => {
-    return option.replace(/'/g, "");
-  });
+  const options = parseLiteralTypes(type);
   return (
     <FormField
       control={form.control}
@@ -225,6 +249,36 @@ function LiteralField({ param, type, form }: TypedFieldProps) {
     />
   );
 }
+
+function MultiLiteralField({ param, type, form }: TypedFieldProps) {
+  const options = parseLiteralTypes(type);
+  if (options.length === 0){
+    console.warn(`MultiLiteralField: There is no options for type "${type}"`);
+  }
+  return (
+    <FormField
+      control={form.control}
+      name={camelCase(param.name)}
+      render={({ field }) => (
+        <FormItem>
+          <div className="inline-flex gap-1">
+            <FormLabel>{snakeToTitleCase(param.name)}</FormLabel>
+            <InfoTooltip>{param.description}</InfoTooltip>
+          </div>
+          <MultiSelectDialog
+            defaultOptions={(field.value as string[]) ?? []}
+            onChange={field.onChange}
+            options={options}
+            placeholder="Select options"
+            selectAll
+          />
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
 
 function BoolField({ param, form }: TypedFieldProps) {
   return (

--- a/packages/widgets/src/lib/create-schema.ts
+++ b/packages/widgets/src/lib/create-schema.ts
@@ -14,14 +14,22 @@ export const createSchema = (parameters: Parameter[]) => {
     const type = annotation?.type ?? "";
     const camelName = camelCase(name);
 
-    if (type.includes("typing.Literal")) {
-      const valuesStr = type.replace("typing.Literal[", "").replace("]", "");
+    if (type.includes("Literal") && !type.includes("list")) {
+      const valuesStr = type.replace("typing.", "").replace("Literal[", "").replace("]", "");
       const valueArray = valuesStr.split(", ").map((v) => v.replace(/'/g, ""));
       schemaFields[camelName] = z.coerce
         .string()
         .refine((val) => valueArray.includes(val), {
           message: `Value must be one of: ${valueArray.join(", ")}`,
         });
+      return;
+    }
+    
+    if (type.includes("Literal") && type.includes("list")) {
+      schemaFields[camelName] = z
+          .array(z.string())
+          .optional()
+          .default([]);
       return;
     }
     switch (type) {

--- a/packages/widgets/src/lib/create-schema.ts
+++ b/packages/widgets/src/lib/create-schema.ts
@@ -14,7 +14,7 @@ export const createSchema = (parameters: Parameter[]) => {
     const type = annotation?.type ?? "";
     const camelName = camelCase(name);
 
-    if (type.includes("Literal") && !type.includes("list")) {
+    if (type.includes("Literal") && !(type.includes("list") || type.includes("Sequence"))) {
       const valuesStr = type.replace("typing.", "").replace("Literal[", "").replace("]", "");
       const valueArray = valuesStr.split(", ").map((v) => v.replace(/'/g, ""));
       schemaFields[camelName] = z.coerce
@@ -25,7 +25,7 @@ export const createSchema = (parameters: Parameter[]) => {
       return;
     }
     
-    if (type.includes("Literal") && type.includes("list")) {
+    if (type.includes("Literal") && (type.includes("list") || type.includes("Sequence"))) {
       schemaFields[camelName] = z
           .array(z.string())
           .optional()


### PR DESCRIPTION
First contribution to the project :)

This PR contains changes in the [schemas](https://github.com/cnpem/sophys-web/commit/21cb746fe0ea2762c3399bb54688a1d3b8e0e6c7) to validate a list of literals and the creation of a [MultiLiteralField](https://github.com/cnpem/sophys-web/commit/07631fd61a4c70faad5357bbdec82efd17738e9a) to support types as:

- `list[Literal[...]]`
- `Sequence[Literal[...]]`
- `list[typing.Literal[...]]`
- `typing.Sequence[Literal[...]]`
- `Sequence[typing.Literal[...]]`

Also introduces a util function to match Literals with a regex.