### PR TITLE
Check severity and nanos for object comparison at PVWS store

### DIFF
--- a/packages/pvws-store/src/lib/utils.ts
+++ b/packages/pvws-store/src/lib/utils.ts
@@ -28,13 +28,27 @@ export const compareSelectedPvMaps =
   };
 
 // Helper function for deep equality of PvData objects (needed for memoization)
+/**
+ * Compares two PvData objects for deep equality.
+ * @param a The first PvData object.
+ * @param b The second PvData object.
+ * @returns True if the objects are equal according to PVWS docs:
+ * "Note how the web socket sends the complete meta data (units etc.)
+ * just once. The following updates then only contain the changed "value",
+ * timestamp "seconds" and "nanos", and maybe alarm "severity""
+ */
 export const comparePvData = (
   a: PvData | undefined,
   b: PvData | undefined,
 ): boolean => {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.value === b.value && a.seconds === b.seconds;
+  return (
+    a.value === b.value &&
+    a.seconds === b.seconds &&
+    a.severity === b.severity &&
+    a.nanos == b.nanos
+  );
 };
 
 export function mergePvDataUpdate(


### PR DESCRIPTION
Since PVWS sends the relevant metadata only once at the subscribe stage and then only update value, seconds, nanos and severity, the comparison must consider all this fields to avoid freezing theses values.

From README: "Note how the web socket sends the complete meta data (units etc.) just once. The following updates then only contain the changed "value", timestamp "seconds" and "nanos", and maybe alarm "severity". Check the pvws.js library as an example for combining the received updates into a complete value, so end users of the data can always conveniently see the complete value while the underlying network traffic is optimized to only transfer changes."

Docs: https://github.com/ornl-epics/pvws/blob/main/README.md