### PR TITLE
feat(ci): Add workflow for deploying PR versions with basePath for testing

### DIFF
--- a/.changeset/some-deer-burn.md
+++ b/.changeset/some-deer-burn.md
@@ -1,0 +1,6 @@
+---
+"@sophys-web/qua-ui": patch
+"@sophys-web/spu-ui": patch
+---
+
+Added ci for deploying pr versions with a set basePath for deployment to the same hostname with added "/pr<pr-number>" to the path for testing purposes.

--- a/.github/workflows/container-pr.yml
+++ b/.github/workflows/container-pr.yml
@@ -1,0 +1,49 @@
+# Adapted workflow for building and pushing Docker images (and replacing if already exists)
+# using a tag format with a 'pr' prefix (e.g., 'qua-ui__pr123' or 'spu-ui__pr456')
+# and setting the .env variable NEXT_PUBLIC_BASE_PATH to '/pr123' so that the temporary deployment can be accessed at https://<app-host>/pr123.
+name: build_and_push_pr
+
+on:
+  push:
+    tags:
+      - "qua-ui__pr*"
+      - "spu-ui__pr*"
+    branches:
+      - main
+
+jobs:
+  build-and-push-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up variables
+        id: vars
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          APP="${TAG%%__*}"
+          VERSION="${TAG#*__}"
+          PR_NUMBER="${TAG#*__pr}"
+          NEXT_PUBLIC_BASE_PATH="/pr${PR_NUMBER}"
+          echo "app=$APP" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "next_public_base_path=$NEXT_PUBLIC_BASE_PATH" >> $GITHUB_OUTPUT
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io/${{ github.repository_owner }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -f apps/${{ steps.vars.outputs.app }}/Dockerfile \
+            --build-arg NEXT_PUBLIC_BASE_PATH=${{ steps.vars.outputs.next_public_base_path }} \
+            -t ghcr.io/${{ github.repository }}__${{ steps.vars.outputs.app }}:${{ steps.vars.outputs.version }} .
+      - name: Push Docker image
+        run: |
+          docker push ghcr.io/${{ github.repository }}__${{ steps.vars.outputs.app }}:${{ steps.vars.outputs.version }}


### PR DESCRIPTION
Created a dedicated ci workflow for setting up a container for deploying PR versions of the apps for testing purposes. 

The workflow is triggered by a tag with a "pr" prefix instead of a "v" prefix of the traditional versioning (e.g., 'qua-ui__pr123'). 

It also sets NEXT_PUBLIC_BASE_PATH with the `pr<number>` part of the tag (e.g.: '/pr123') so the test app can be deployed with a path prefix, since this needs to be set at build time (see: https://nextjs.org/docs/app/api-reference/config/next-config-js/basePath). This allows for easier identification of test versions and enables multiple deployments in the same host.

