### PR TITLE
fix(packages/ui): Fixed cumulative increment in AccordionContent height

### DIFF
--- a/.changeset/strict-doodles-vanish.md
+++ b/.changeset/strict-doodles-vanish.md
@@ -1,0 +1,5 @@
+---
+"@sophys-web/ui": patch
+---
+
+Fixed cumulative increment in accordion content height on status change. The AccordionContent height increasingly grows on successive status changes (open/closed). This behavior is fixed by removing h-(--radix-accordion-content-height) class, to allow the div to grow to the height of its content.

--- a/packages/ui/src/accordion.tsx
+++ b/packages/ui/src/accordion.tsx
@@ -73,7 +73,8 @@ function AccordionContent({
     >
       <div
         className={cn(
-          "[&_a]:hover:text-foreground h-(--radix-accordion-content-height) pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+          // FIX: The  AccordionContent height increasingly grows on successive status changes (open/closed). This is fixed by removing h-(--radix-accordion-content-height) class, to allow the div to grow to the height of its content.
+          "[&_a]:hover:text-foreground pt-0 pb-2.5 [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
           className,
         )}
       >


### PR DESCRIPTION
Fix to a height effect that can happen to dynamic renders in AccordionContent. 

With bug:
<img width="300"  alt="accordion-bug" src="https://github.com/user-attachments/assets/46a1be93-3dc7-46fe-9ea1-cb74b16f73b4" />


Fixed:
<img width="300"  alt="accordion-fixed" src="https://github.com/user-attachments/assets/6b65f98c-9e7f-44b0-8d24-8b5763f32c21" />