### PR TITLE
refactor(apps/spu-ui): support two types of sample cards in setup2 store

### DIFF
--- a/.changeset/eighty-animals-drum.md
+++ b/.changeset/eighty-animals-drum.md
@@ -1,0 +1,5 @@
+---
+"@sophys-web/spu-ui": minor
+---
+
+Refactor setup2 store to support two types of samples: "capillary" and "standard" (grid).

--- a/.changeset/thin-actors-own.md
+++ b/.changeset/thin-actors-own.md
@@ -1,0 +1,5 @@
+---
+"@sophys-web/spu-ui": minor
+---
+
+Setup2: Add support for move_inside_card plan for capillary card.

--- a/apps/spu-ui/src/app/_components/plans/setup2-complete-acquisition-form.tsx
+++ b/apps/spu-ui/src/app/_components/plans/setup2-complete-acquisition-form.tsx
@@ -61,12 +61,16 @@ const schema = z
       .number()
       .int()
       .min(1, "Number of exposures must be at least 1"),
-    col: z.enum(cardColumns, {
-      message: `Column must be one of the following options ${cardColumns.join(", ")}`,
-    }),
-    row: z.enum(cardRows, {
-      message: `Row must be one of the following options ${cardRows.join(", ")}`,
-    }),
+    col: z
+      .enum(cardColumns, {
+        message: `Column must be one of the following options ${cardColumns.join(", ")}`,
+      })
+      .optional(),
+    row: z
+      .enum(cardRows, {
+        message: `Row must be one of the following options ${cardRows.join(", ")}`,
+      })
+      .optional(),
     cardIndex: z
       .enum(cardIndexOptions, {
         message: `Card index must be one of the following options ${cardIndexOptions.join(", ")}`,
@@ -92,11 +96,20 @@ const name = "setup2_complete_standard_acquisition";
 
 export function CompleteAcquisitionForm({
   sampleParams,
+  cardPosition,
+  cardIndex,
   cardName,
   className,
   onSubmitSuccess,
 }: {
   sampleParams: Sample | undefined;
+  cardPosition:
+    | {
+        row: (typeof cardRows)[number];
+        column: (typeof cardColumns)[number];
+      }
+    | undefined;
+  cardIndex: (typeof cardIndexOptions)[number] | undefined;
   cardName?: string | undefined;
   className?: string;
   onSubmitSuccess: () => void;
@@ -111,15 +124,16 @@ export function CompleteAcquisitionForm({
       sampleTag: sampleParams?.sampleTag ?? "",
       acquireTime: 0.1,
       numExposures: 1,
-      col: sampleParams?.column ?? "A",
-      row: sampleParams?.row ?? "1",
-      cardIndex: sampleParams?.cardIndex,
+      cardIndex: cardIndex,
       cardName: cardName ?? "",
       retrieveCard: true,
       usePimega: true,
       usePicolo: false,
-      samplePosX: sampleParams?.samplePositionX,
-      samplePosY: sampleParams?.samplePositionY,
+      samplePosX: sampleParams?.position?.x,
+      samplePosY: sampleParams?.position?.y,
+      ...(cardPosition
+        ? { col: cardPosition.column, row: cardPosition.row }
+        : {}),
     },
   });
 

--- a/apps/spu-ui/src/app/_components/plans/setup2-move-inside-card-form.tsx
+++ b/apps/spu-ui/src/app/_components/plans/setup2-move-inside-card-form.tsx
@@ -18,28 +18,24 @@ import {
   InputGroupInput,
 } from "@sophys-web/ui/input-group";
 import { InfoTooltip } from "@sophys-web/widgets/form-components/info-tooltip";
-import { cardSlotRadius } from "../store/setup2/constants";
-import { isValidCardCoordinatesGridSlot } from "../store/setup2/use-sample-store";
+import { capillaryCardSlotLimitsMilimeters } from "../store/setup2/constants";
 
-const name = "setup2_move_inside_sample";
+const name = "setup2_move_inside_card";
 
 const schema = z.object({
-  x: z.coerce.number(),
-  y: z.coerce.number(),
+  x: z.coerce
+    .number()
+    .min(capillaryCardSlotLimitsMilimeters.x.min)
+    .max(capillaryCardSlotLimitsMilimeters.x.max),
+  y: z.coerce
+    .number()
+    .min(capillaryCardSlotLimitsMilimeters.y.min)
+    .max(capillaryCardSlotLimitsMilimeters.y.max),
 });
-
-const schemaRadius = schema.refine(
-  (data) => isValidCardCoordinatesGridSlot({ x: data.x, y: data.y }),
-  (data) => ({
-    message: `Coordinates must be within a circle of radius ${cardSlotRadius}mm. 
-    Radius for (${data.x},${data.y}): ${Math.sqrt(data.x ** 2 + data.y ** 2).toFixed(2)}`,
-    path: ["x"],
-  }),
-);
 
 export { name, schema };
 
-export function MoveInsideSampleForm({
+export function MoveInsideCardForm({
   className,
   onSubmitSuccess,
   x,
@@ -52,16 +48,16 @@ export function MoveInsideSampleForm({
 }) {
   const { add } = useQueue();
   const form = useForm({
-    resolver: zodResolver(schemaRadius),
+    resolver: zodResolver(schema),
     defaultValues: {
       x: x ?? 0,
       y: y ?? 0,
     },
   });
 
-  function onSubmit(data: z.infer<typeof schemaRadius>) {
+  function onSubmit(data: z.infer<typeof schema>) {
     toast.info("Submitting sample...");
-    const kwargs = schemaRadius.parse(data);
+    const kwargs = schema.parse(data);
     add.mutate(
       {
         item: {
@@ -103,8 +99,7 @@ export function MoveInsideSampleForm({
                   Sample X
                   <InfoTooltip>
                     <FieldDescription>
-                      Position X of the sample on the card slot. Must be within
-                      a circle of radius {cardSlotRadius}mm.
+                      Position X of the sample on the card slot.
                     </FieldDescription>
                   </InfoTooltip>
                 </FieldLabel>
@@ -137,8 +132,7 @@ export function MoveInsideSampleForm({
                   Sample Y
                   <InfoTooltip>
                     <FieldDescription>
-                      Position Y of the sample on the card slot. Must be within
-                      a circle of radius {cardSlotRadius}mm.
+                      Position Y of the sample on the card slot.
                     </FieldDescription>
                   </InfoTooltip>
                 </FieldLabel>

--- a/apps/spu-ui/src/app/_components/plans/setup2-move-inside-sample-form.tsx
+++ b/apps/spu-ui/src/app/_components/plans/setup2-move-inside-sample-form.tsx
@@ -18,7 +18,9 @@ import {
   InputGroupInput,
 } from "@sophys-web/ui/input-group";
 import { InfoTooltip } from "@sophys-web/widgets/form-components/info-tooltip";
-import { cardSlotRadius, isValidCardPosition } from "../store/setup2/constants";
+import type { cardModes } from "../store/setup2/constants";
+import { cardSlotRadius } from "../store/setup2/constants";
+import { isValidCardCoordinates } from "../store/setup2/use-sample-store";
 
 const name = "setup2_move_inside_sample";
 
@@ -27,8 +29,8 @@ const schema = z.object({
   y: z.coerce.number(),
 });
 
-const schemaRefined = schema.refine(
-  (data) => isValidCardPosition({ x: data.x, y: data.y }),
+const schemaRadius = schema.refine(
+  (data) => isValidCardCoordinates({ x: data.x, y: data.y }),
   (data) => ({
     message: `Coordinates must be within a circle of radius ${cardSlotRadius}mm. 
     Radius for (${data.x},${data.y}): ${Math.sqrt(data.x ** 2 + data.y ** 2).toFixed(2)}`,
@@ -43,24 +45,27 @@ export function MoveInsideSampleForm({
   onSubmitSuccess,
   x,
   y,
+  cardType = "standard",
 }: {
   className?: string;
   onSubmitSuccess?: () => void;
   x?: z.infer<typeof schema.shape.x>;
   y?: z.infer<typeof schema.shape.y>;
+  cardType: (typeof cardModes)[number];
 }) {
+  const cardSchema = cardType === "standard" ? schemaRadius : schema;
   const { add } = useQueue();
   const form = useForm({
-    resolver: zodResolver(schemaRefined),
+    resolver: zodResolver(cardSchema),
     defaultValues: {
       x: x ?? 0,
       y: y ?? 0,
     },
   });
 
-  function onSubmit(data: z.infer<typeof schemaRefined>) {
+  function onSubmit(data: z.infer<typeof cardSchema>) {
     toast.info("Submitting sample...");
-    const kwargs = schemaRefined.parse(data);
+    const kwargs = cardSchema.parse(data);
     add.mutate(
       {
         item: {

--- a/apps/spu-ui/src/app/_components/store/setup2/constants.ts
+++ b/apps/spu-ui/src/app/_components/store/setup2/constants.ts
@@ -12,9 +12,20 @@ export const cardIndexOptions = [
 ] as const;
 export const cardColumns = ["A", "B", "C", "D"] as const;
 export const cardRows = ["1", "2", "3", "4", "5", "6"] as const;
+export const cardCapillaryColumns = [
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "I",
+  "J",
+  "K",
+] as const;
 export const cardModes = ["standard", "capillary"] as const;
+export const cardTypesGrid = cardModes[0];
+export const cardTypesCapillary = cardModes[1];
 export const cardSlotRadius = 2;
-
-export function isValidCardPosition({ x, y }: { x: number; y: number }) {
-  return Math.sqrt(x ** 2 + y ** 2) <= cardSlotRadius;
-}

--- a/apps/spu-ui/src/app/_components/store/setup2/constants.ts
+++ b/apps/spu-ui/src/app/_components/store/setup2/constants.ts
@@ -29,3 +29,7 @@ export const cardModes = ["standard", "capillary"] as const;
 export const cardTypesGrid = cardModes[0];
 export const cardTypesCapillary = cardModes[1];
 export const cardSlotRadius = 2;
+export const capillaryCardSlotLimitsMilimeters = {
+  x: { min: 0, max: 35 },
+  y: { min: 0, max: 50 },
+};

--- a/apps/spu-ui/src/app/_components/store/setup2/register-sample-form.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/register-sample-form.tsx
@@ -16,20 +16,29 @@ import {
   InputGroupInput,
 } from "@sophys-web/ui/input-group";
 import { InfoTooltip } from "@sophys-web/widgets/form-components/info-tooltip";
+import type { cardModes } from "./constants";
 import type { Sample } from "./use-sample-store";
 import { cardSlotRadius } from "./constants";
-import { sampleSchema, useSampleStore } from "./use-sample-store";
+import {
+  sampleSchema,
+  sampleSchemaValidPosition,
+  useSampleStore,
+} from "./use-sample-store";
 
 export function EditSampleForm({
   sample,
   onSubmitCallback,
+  cardType = "standard",
 }: {
   sample: Sample;
   onSubmitCallback?: () => void;
+  cardType?: (typeof cardModes)[number];
 }) {
+  const schema =
+    cardType === "standard" ? sampleSchemaValidPosition : sampleSchema;
   const { setSample } = useSampleStore();
   const form = useForm({
-    resolver: zodResolver(sampleSchema),
+    resolver: zodResolver(schema),
     defaultValues: {
       position: {
         x: 0,
@@ -39,7 +48,7 @@ export function EditSampleForm({
     },
   });
 
-  async function onSubmit(data: z.infer<typeof sampleSchema>) {
+  async function onSubmit(data: z.infer<typeof schema>) {
     toast.info("Registering sample...");
     await setSample(data.id, data).then(() => {
       toast.success("Sample registered!");
@@ -91,7 +100,8 @@ export function EditSampleForm({
                     <InfoTooltip>
                       <FieldDescription>
                         Position X of the sample on the card slot. Must be
-                        within a circle of radius {cardSlotRadius}mm.
+                        within a circle of radius {cardSlotRadius}mm for samples
+                        in the standard (grid) card type.
                       </FieldDescription>
                     </InfoTooltip>
                   </FieldLabel>

--- a/apps/spu-ui/src/app/_components/store/setup2/register-sample-form.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/register-sample-form.tsx
@@ -16,70 +16,32 @@ import {
   InputGroupInput,
 } from "@sophys-web/ui/input-group";
 import { InfoTooltip } from "@sophys-web/widgets/form-components/info-tooltip";
-import type { cardColumns, cardIndexOptions, cardRows } from "./constants";
 import type { Sample } from "./use-sample-store";
-import { cardSlotRadius, isValidCardPosition } from "./constants";
-import {
-  sampleIdFromPosition,
-  sampleSchema,
-  useSampleStore,
-} from "./use-sample-store";
+import { cardSlotRadius } from "./constants";
+import { sampleSchema, useSampleStore } from "./use-sample-store";
 
-const registerSchema = sampleSchema
-  .omit({
-    id: true,
-  })
-  .refine(
-    (data) =>
-      isValidCardPosition({ x: data.samplePositionX, y: data.samplePositionY }),
-    (data) => ({
-      message: `Sample position must be within a circle of radius ${cardSlotRadius}. 
-      Position for (${data.samplePositionX},${data.samplePositionY}): ${Math.sqrt(data.samplePositionX ** 2 + data.samplePositionY ** 2).toFixed(2)}`,
-      path: ["samplePositionX"],
-    }),
-  );
-
-export function RegisterSampleForm({
-  cardIndex,
-  row,
-  column,
-  sampleTag,
-  samplePositionX = 0,
-  samplePositionY = 0,
-  meta = "",
+export function EditSampleForm({
+  sample,
   onSubmitCallback,
 }: {
-  cardIndex: (typeof cardIndexOptions)[number];
-  row: (typeof cardRows)[number];
-  column: (typeof cardColumns)[number];
-  sampleTag?: string;
-  samplePositionX?: number;
-  samplePositionY?: number;
-  meta?: string;
+  sample: Sample;
   onSubmitCallback?: () => void;
 }) {
   const { setSample } = useSampleStore();
   const form = useForm({
-    resolver: zodResolver(registerSchema),
+    resolver: zodResolver(sampleSchema),
     defaultValues: {
-      sampleTag: sampleTag ?? "",
-      row,
-      column,
-      cardIndex,
-      samplePositionX,
-      samplePositionY,
-      meta,
+      position: {
+        x: 0,
+        y: 0,
+      },
+      ...sample,
     },
   });
 
-  async function onSubmit(data: z.infer<typeof registerSchema>) {
+  async function onSubmit(data: z.infer<typeof sampleSchema>) {
     toast.info("Registering sample...");
-    const sampleId = sampleIdFromPosition({ cardIndex, row, column });
-    const sample = {
-      id: sampleId,
-      ...data,
-    } satisfies Sample;
-    await setSample(sampleId, sample).then(() => {
+    await setSample(data.id, data).then(() => {
       toast.success("Sample registered!");
       form.reset();
       onSubmitCallback?.();
@@ -120,7 +82,7 @@ export function RegisterSampleForm({
           <FieldLabel>Sample Position in the Slot</FieldLabel>
           <FieldGroup className="grid grid-cols-2 gap-4">
             <Controller
-              name="samplePositionX"
+              name="position.x"
               control={form.control}
               render={({ field, fieldState }) => (
                 <Field data-invalid={fieldState.invalid}>
@@ -154,7 +116,7 @@ export function RegisterSampleForm({
               )}
             />
             <Controller
-              name="samplePositionY"
+              name="position.y"
               control={form.control}
               render={({ field, fieldState }) => (
                 <Field data-invalid={fieldState.invalid}>
@@ -190,15 +152,15 @@ export function RegisterSampleForm({
           </FieldGroup>
         </FieldSet>
         <Controller
-          name="meta"
+          name="notes"
           control={form.control}
           render={({ field, fieldState }) => (
             <Field>
-              <FieldLabel htmlFor="meta">
-                Metadata
+              <FieldLabel htmlFor="notes">
+                Notes
                 <InfoTooltip>
                   <FieldDescription>
-                    Additional metadata for this sample.
+                    Additional notes for this sample.
                   </FieldDescription>
                 </InfoTooltip>
               </FieldLabel>
@@ -224,49 +186,33 @@ export function RegisterSampleForm({
 }
 
 export function RegisterNewSampleForm({
-  cardIndex,
-  row,
-  column,
-  sampleTag,
-  meta = "",
+  sampleId,
   onSubmitCallback,
 }: {
-  cardIndex: (typeof cardIndexOptions)[number];
-  row: (typeof cardRows)[number];
-  column: (typeof cardColumns)[number];
-  sampleTag?: string;
-  samplePositionX?: number;
-  samplePositionY?: number;
-  meta?: string;
+  sampleId: string;
   onSubmitCallback?: () => void;
 }) {
   const { setSample } = useSampleStore();
   const form = useForm({
-    resolver: zodResolver(registerSchema),
+    resolver: zodResolver(sampleSchema),
     defaultValues: {
-      sampleTag: sampleTag ?? "",
-      row,
-      column,
-      cardIndex,
-      samplePositionX: 0,
-      samplePositionY: 0,
-      meta,
+      id: sampleId,
+      sampleTag: "",
+      position: undefined,
+      notes: "",
     },
   });
 
-  async function onSubmit(data: z.infer<typeof registerSchema>) {
+  async function onSubmit(data: z.infer<typeof sampleSchema>) {
     toast.info("Registering sample...");
-    const sampleId = sampleIdFromPosition({ cardIndex, row, column });
-    const sample = {
-      id: sampleId,
-      ...data,
-    } satisfies Sample;
-    await setSample(sampleId, sample).then(() => {
+    await setSample(sampleId, data).then(() => {
       toast.success("Sample registered!");
       form.reset();
       onSubmitCallback?.();
     });
   }
+
+  const errors = form.formState.errors;
 
   return (
     <form onSubmit={form.handleSubmit(onSubmit)}>
@@ -298,15 +244,15 @@ export function RegisterNewSampleForm({
           )}
         />
         <Controller
-          name="meta"
+          name="notes"
           control={form.control}
           render={({ field, fieldState }) => (
             <Field>
-              <FieldLabel htmlFor="meta">
-                Metadata
+              <FieldLabel htmlFor="notes">
+                Notes
                 <InfoTooltip>
                   <FieldDescription>
-                    Additional metadata for this sample.
+                    Additional notes for this sample.
                   </FieldDescription>
                 </InfoTooltip>
               </FieldLabel>
@@ -324,6 +270,17 @@ export function RegisterNewSampleForm({
           )}
         />
       </FieldGroup>
+      {/* render other form validation errors */}
+      {Object.keys(errors).length > 0 && (
+        <div className="error-banner">
+          <h4>Please fix the following errors:</h4>
+          <ul>
+            {Object.values(errors).map((error, index) => (
+              <li key={index}>{error.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
       <Button type="submit" className="w-full">
         Submit
       </Button>

--- a/apps/spu-ui/src/app/_components/store/setup2/sample-item.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/sample-item.tsx
@@ -30,8 +30,10 @@ import { Setup2AquisitionForm } from "../../plans/setup2-acquisition";
 import { CompleteAcquisitionForm } from "../../plans/setup2-complete-acquisition-form";
 import { Setup2FindSampleHorizontalScanForm } from "../../plans/setup2-find-sample-horizontal-scan";
 import { Setup2FindSampleVerticalScanForm } from "../../plans/setup2-find-sample-vertical-scan";
+import { MoveInsideCardForm } from "../../plans/setup2-move-inside-card-form";
 import { MoveInsideSampleForm } from "../../plans/setup2-move-inside-sample-form";
 import { MoveToSampleForm } from "../../plans/setup2-move-to-sample-form";
+import { capillaryCardSlotLimitsMilimeters } from "./constants";
 import { DeleteSampleForm } from "./delete-sample-form";
 import { EditSampleForm, RegisterNewSampleForm } from "./register-sample-form";
 import { sampleIdDecoder, useSampleStore } from "./use-sample-store";
@@ -207,15 +209,24 @@ function SampleDropdownMenu({
           onSubmitCallback={() => setOpen(false)}
         />
         <DropdownMenuSeparator />
-        <MoveToSampleMenuItem
-          sample={sample}
-          onSubmitCallback={() => setOpen(false)}
-        />
-        <MoveInsideSampleMenuItem
-          sample={sample}
-          onSubmitCallback={() => setOpen(false)}
-          cardType={cardType}
-        />
+        {cardType === "standard" && (
+          <MoveToSampleMenuItem
+            sample={sample}
+            onSubmitCallback={() => setOpen(false)}
+          />
+        )}
+        {cardType === "standard" && (
+          <MoveInsideSampleMenuItem
+            sample={sample}
+            onSubmitCallback={() => setOpen(false)}
+          />
+        )}
+        {cardType === "capillary" && (
+          <MoveInsideCardMenuItem
+            sample={sample}
+            onSubmitCallback={() => setOpen(false)}
+          />
+        )}
         <FindSampleVerticalMenuItem
           sample={sample}
           onSubmitCallback={() => setOpen(false)}
@@ -487,11 +498,9 @@ function MoveToSampleMenuItem({
 function MoveInsideSampleMenuItem({
   sample,
   onSubmitCallback,
-  cardType = "standard",
 }: {
   sample: Sample;
   onSubmitCallback?: () => void;
-  cardType: (typeof cardModes)[number];
 }) {
   const [open, setOpen] = useState(false);
   const handleOpen = (e: Event) => {
@@ -522,7 +531,52 @@ function MoveInsideSampleMenuItem({
           x={sample.position?.x}
           y={sample.position?.y}
           onSubmitSuccess={handleSubmitSuccess}
-          cardType={cardType}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MoveInsideCardMenuItem({
+  sample,
+  onSubmitCallback,
+}: {
+  sample: Sample;
+  onSubmitCallback?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const handleOpen = (e: Event) => {
+    e.preventDefault();
+    setOpen(true);
+  };
+  const handleSubmitSuccess = () => {
+    setOpen(false);
+    onSubmitCallback?.();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <DropdownMenuItem onSelect={handleOpen}>
+          <CircleDotIcon className="mr-2 size-4" />
+          Move Inside Card
+        </DropdownMenuItem>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Move Inside Card</DialogTitle>
+          <DialogDescription className="flex flex-col items-center">
+            Move inside the capillary card window within the constraints for x:{" "}
+            {`[${capillaryCardSlotLimitsMilimeters.x.min}, ${capillaryCardSlotLimitsMilimeters.x.max}]`}{" "}
+            and y:{" "}
+            {`[${capillaryCardSlotLimitsMilimeters.y.min}, ${capillaryCardSlotLimitsMilimeters.y.max}]`}
+            .
+          </DialogDescription>
+        </DialogHeader>
+        <MoveInsideCardForm
+          x={sample.position?.x}
+          y={sample.position?.y}
+          onSubmitSuccess={handleSubmitSuccess}
         />
       </DialogContent>
     </Dialog>

--- a/apps/spu-ui/src/app/_components/store/setup2/sample-item.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/sample-item.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { cva } from "class-variance-authority";
 import {
   CameraIcon,
   CircleArrowRightIcon,
@@ -8,7 +9,6 @@ import {
   PlusIcon,
 } from "lucide-react";
 import { cn } from "@sophys-web/ui";
-import { Button } from "@sophys-web/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -24,6 +24,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@sophys-web/ui/dropdown-menu";
+import type { cardModes } from "./constants";
 import type { Sample } from "./use-sample-store";
 import { Setup2AquisitionForm } from "../../plans/setup2-acquisition";
 import { CompleteAcquisitionForm } from "../../plans/setup2-complete-acquisition-form";
@@ -31,87 +32,92 @@ import { Setup2FindSampleHorizontalScanForm } from "../../plans/setup2-find-samp
 import { Setup2FindSampleVerticalScanForm } from "../../plans/setup2-find-sample-vertical-scan";
 import { MoveInsideSampleForm } from "../../plans/setup2-move-inside-sample-form";
 import { MoveToSampleForm } from "../../plans/setup2-move-to-sample-form";
-import { cardColumns, cardIndexOptions, cardRows } from "./constants";
 import { DeleteSampleForm } from "./delete-sample-form";
-// import { LoadSampleForm } from "./load-sample-form";
-import {
-  RegisterNewSampleForm,
-  RegisterSampleForm,
-} from "./register-sample-form";
-import { useSampleCardName } from "./sample-store";
-import { positionFromSampleId, useSampleStore } from "./use-sample-store";
+import { EditSampleForm, RegisterNewSampleForm } from "./register-sample-form";
+import { sampleIdDecoder, useSampleStore } from "./use-sample-store";
+
+const sampleTypeVariants = cva(
+  "flex items-center justify-around border text-sm",
+  {
+    variants: {
+      cardType: {
+        standard: "size-10 rounded-full",
+        capillary: "h-32 w-6 rounded-md",
+      },
+      registerState: {
+        unregistered:
+          "bg-muted cursor-cell text-gray-800 hover:bg-gray-100 hover:ring hover:ring-gray-400",
+
+        registered:
+          "hover:ring-primary/50 cursor-context-menu border-orange-800/10 bg-orange-300 text-gray-800 hover:bg-orange-300/90 hover:ring",
+      },
+    },
+    defaultVariants: {
+      cardType: "standard",
+      registerState: "unregistered",
+    },
+  },
+);
 
 /**
  * Sample item component representing an empty slot or a registered sample.
- * @param sample - The sample data or undefined if the slot is empty.
  * @param sampleId - The unique identifier for the sample slot.
  *
  * @example
- * <SampleItem sample={sample} sampleId="Tray1-A1" />
+ * <SampleItem sampleId="Tray1-A1" />
  */
 export function SampleItem({
-  sample,
   sampleId,
+  cardType,
 }: {
-  sample: Sample | undefined;
   sampleId: string;
+  cardType: (typeof cardModes)[number];
 }) {
+  const { storeData } = useSampleStore();
+  const sample = storeData?.[sampleId];
   // if sample is undefined, render empty slot
   if (!sample) {
-    return <EmptySampleSlotDialog sampleId={sampleId} />;
+    return <EmptySampleSlotDialog sampleId={sampleId} cardType={cardType} />;
   }
 
   // if sample is defined, render registered sample
-  return <SampleDropdownMenu sample={sample} />;
+  return <SampleDropdownMenu sample={sample} cardType={cardType} />;
 }
 
 function EmptySampleSlotDialog({
   sampleId,
-  trigger,
+  cardType,
 }: {
   sampleId: string;
-  trigger?: React.ReactNode;
+  cardType: (typeof cardModes)[number];
 }) {
   const [open, setOpen] = useState(false);
-  const { cardIndex, row, column } = positionFromSampleId(sampleId);
   const { error } = useSampleStore();
 
-  // check if tray, row and col are valid values, if not return null
-  if (
-    !cardIndexOptions.includes(
-      cardIndex as (typeof cardIndexOptions)[number],
-    ) ||
-    !cardRows.includes(row as (typeof cardRows)[number]) ||
-    !cardColumns.includes(column as (typeof cardColumns)[number])
-  ) {
-    return null;
-  }
   return (
     <Dialog onOpenChange={setOpen} open={open}>
-      {!trigger && (
-        <DialogTrigger asChild>
-          <Button
-            variant="outline"
-            size="icon"
-            className="cursor-cell rounded-full bg-zinc-100 text-sm opacity-50 select-none hover:scale-105 hover:ring hover:ring-slate-400"
-            disabled={!!error}
-          >
-            <PlusIcon className="size-4" />
-          </Button>
-        </DialogTrigger>
-      )}
-      {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
+      <DialogTrigger asChild>
+        <button
+          className={cn(
+            sampleTypeVariants({
+              cardType: cardType,
+              registerState: "unregistered",
+            }),
+          )}
+          disabled={!!error}
+        >
+          <PlusIcon className="size-4" />
+        </button>
+      </DialogTrigger>
       <DialogContent className="flex w-fit flex-col items-center">
         <DialogHeader>
           <DialogTitle>Register new sample</DialogTitle>
           <DialogDescription className="flex flex-col items-start">
-            <span>{`position: ${cardIndex}-${row}${column}`}</span>
+            <span>{`position: ${sampleId}`}</span>
           </DialogDescription>
         </DialogHeader>
         <RegisterNewSampleForm
-          cardIndex={cardIndex as (typeof cardIndexOptions)[number]}
-          row={row as (typeof cardRows)[number]}
-          column={column as (typeof cardColumns)[number]}
+          sampleId={sampleId}
           onSubmitCallback={() => setOpen(false)}
         />
       </DialogContent>
@@ -129,19 +135,19 @@ function SampleInfo({
   return (
     <div className={cn("flex w-40 flex-col items-start gap-1", className)}>
       <p>
-        <span className="font-bold">Index:</span>{" "}
-        {`${sample.cardIndex}-${sample.row}${sample.column}`}
+        <span className="font-bold">Index:</span>
+        {sample.id}
       </p>
       <p>
         <span className="font-bold">Name:</span> {sample.sampleTag}
       </p>
       <p>
-        <span className="font-bold">Position:</span> ({sample.samplePositionX},{" "}
-        {sample.samplePositionY})
+        <span className="font-bold">Position:</span> ({sample.position?.x},{" "}
+        {sample.position?.y})
       </p>
-      {sample.meta && (
+      {sample.notes && (
         <p className="overflow-wrap">
-          <span className="font-bold">Meta:</span> {sample.meta}
+          <span className="font-bold">Notes:</span> {sample.notes}
         </p>
       )}
     </div>
@@ -152,23 +158,36 @@ export const defaultSampleStyle =
   "border border-gray-300 bg-orange-300 text-gray-800 hover:bg-gray-100";
 
 function SampleDropdownTrigger({ sample }: { sample: Sample }) {
+  const decoded = sampleIdDecoder.safeParse(sample.id);
+  if (!decoded.success) {
+    console.error("Failed to decode sample ID:", decoded.error);
+    return <div className={cn("text-destructive")}>?</div>;
+  }
+  const { position, type } = decoded.data;
   return (
     <DropdownMenuTrigger asChild>
-      <Button
-        variant="outline"
-        size="icon"
+      <button
         className={cn(
-          "cursor-context-menu rounded-full text-sm select-none hover:scale-105 hover:ring",
-          defaultSampleStyle,
+          sampleTypeVariants({
+            cardType: type,
+            registerState: "registered",
+          }),
         )}
       >
-        {`${sample.row}${sample.column}`}
-      </Button>
+        {type === "capillary" && "s"}
+        {type === "standard" && `${position.column}${position.row}`}
+      </button>
     </DropdownMenuTrigger>
   );
 }
 
-function SampleDropdownMenu({ sample }: { sample: Sample }) {
+function SampleDropdownMenu({
+  sample,
+  cardType,
+}: {
+  sample: Sample;
+  cardType: (typeof cardModes)[number];
+}) {
   const [open, setOpen] = useState(false);
   return (
     <DropdownMenu modal={false} open={open} onOpenChange={setOpen}>
@@ -194,6 +213,7 @@ function SampleDropdownMenu({ sample }: { sample: Sample }) {
         <MoveInsideSampleMenuItem
           sample={sample}
           onSubmitCallback={() => setOpen(false)}
+          cardType={cardType}
         />
         <FindSampleVerticalMenuItem
           sample={sample}
@@ -245,17 +265,11 @@ function EditSampleMenuItem({
         <DialogHeader>
           <DialogTitle>Register sample</DialogTitle>
           <DialogDescription className="flex flex-col items-start">
-            <span>{`position: ${sample.cardIndex}-${sample.row}${sample.column}`}</span>
+            <span>{`id: ${sample.id}`}</span>
           </DialogDescription>
         </DialogHeader>
-        <RegisterSampleForm
-          cardIndex={sample.cardIndex}
-          row={sample.row}
-          column={sample.column}
-          sampleTag={sample.sampleTag}
-          samplePositionX={sample.samplePositionX}
-          samplePositionY={sample.samplePositionY}
-          meta={sample.meta}
+        <EditSampleForm
+          sample={sample}
           onSubmitCallback={handleSubmitSuccess}
         />
       </DialogContent>
@@ -290,7 +304,9 @@ function DeleteSampleMenuItem({
       <DialogContent className="flex w-fit flex-col items-center">
         <DialogHeader>
           <DialogTitle>Deleting sample</DialogTitle>
-          <DialogDescription className="flex flex-col items-start"></DialogDescription>
+          <DialogDescription className="flex flex-col items-start">
+            {`id: ${sample.id}`}
+          </DialogDescription>
         </DialogHeader>
         <SampleInfo sample={sample} />
         <DeleteSampleForm
@@ -318,7 +334,27 @@ function CompleteAcquisitionMenuItem({
     setOpen(false);
     onSubmitCallback?.();
   };
-  const { cardName } = useSampleCardName(sample.cardIndex);
+
+  const decoded = sampleIdDecoder.safeParse(sample.id);
+  if (!decoded.success) {
+    console.error("Failed to decode sample ID:", decoded.error);
+    return (
+      <DropdownMenuItem disabled>
+        <CameraIcon className="mr-2 h-4 w-4" />
+        Complete Acquisition
+      </DropdownMenuItem>
+    );
+  }
+  const { card, position, type } = decoded.data;
+
+  if (type === "capillary") {
+    return (
+      <DropdownMenuItem disabled>
+        <CameraIcon className="mr-2 h-4 w-4" />
+        Complete Acquisition
+      </DropdownMenuItem>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -333,12 +369,13 @@ function CompleteAcquisitionMenuItem({
           <DialogTitle>Complete Acquisition</DialogTitle>
           <DialogDescription className="flex flex-col items-center">
             Complete acquisition for sample {sample.sampleTag} at position{" "}
-            {`${sample.cardIndex}-${sample.row}${sample.column}`}
+            {`${position.column}${position.row}`} on card {card}.
           </DialogDescription>
         </DialogHeader>
         <CompleteAcquisitionForm
           sampleParams={sample}
-          cardName={cardName ?? undefined}
+          cardPosition={position}
+          cardIndex={card}
           onSubmitSuccess={handleSubmitSuccess}
         />
       </DialogContent>
@@ -405,6 +442,18 @@ function MoveToSampleMenuItem({
     setOpen(false);
     onSubmitCallback?.();
   };
+  const decoded = sampleIdDecoder.safeParse(sample.id);
+
+  if (!decoded.success || decoded.data.type === "capillary") {
+    if (!decoded.success)
+      console.error("Failed to decode sample ID:", decoded.error);
+    return (
+      <DropdownMenuItem disabled>
+        <CircleArrowRightIcon className="mr-2 size-4" />
+        Move to Sample
+      </DropdownMenuItem>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -418,13 +467,12 @@ function MoveToSampleMenuItem({
         <DialogHeader>
           <DialogTitle>Move to Sample</DialogTitle>
           <DialogDescription className="flex flex-col items-center">
-            Move to sample {sample.sampleTag} at position{" "}
-            {`${sample.cardIndex}-${sample.row}${sample.column}`}
+            Move to sample {sample.sampleTag} at {sample.id}
           </DialogDescription>
         </DialogHeader>
         <MoveToSampleForm
-          row={sample.row}
-          col={sample.column}
+          row={decoded.data.position.row}
+          col={decoded.data.position.column}
           onSubmitSuccess={handleSubmitSuccess}
         />
       </DialogContent>
@@ -435,9 +483,11 @@ function MoveToSampleMenuItem({
 function MoveInsideSampleMenuItem({
   sample,
   onSubmitCallback,
+  cardType = "standard",
 }: {
   sample: Sample;
   onSubmitCallback?: () => void;
+  cardType: (typeof cardModes)[number];
 }) {
   const [open, setOpen] = useState(false);
   const handleOpen = (e: Event) => {
@@ -461,14 +511,14 @@ function MoveInsideSampleMenuItem({
         <DialogHeader>
           <DialogTitle>Move Inside Sample</DialogTitle>
           <DialogDescription className="flex flex-col items-center">
-            Move inside sample {sample.sampleTag} at position{" "}
-            {`${sample.cardIndex}-${sample.row}${sample.column}`}
+            Move inside sample
           </DialogDescription>
         </DialogHeader>
         <MoveInsideSampleForm
-          x={sample.samplePositionX}
-          y={sample.samplePositionY}
+          x={sample.position?.x}
+          y={sample.position?.y}
           onSubmitSuccess={handleSubmitSuccess}
+          cardType={cardType}
         />
       </DialogContent>
     </Dialog>
@@ -512,7 +562,7 @@ function FindSampleVerticalMenuItem({
           onSubmitSuccess={handleSubmitSuccess}
           params={{
             sampleTag: sample.sampleTag,
-            posX: sample.samplePositionX,
+            posX: sample.position?.x,
           }}
         />
       </DialogContent>
@@ -557,7 +607,7 @@ function FindSampleHorizontalMenuItem({
           onSubmitSuccess={handleSubmitSuccess}
           params={{
             sampleTag: sample.sampleTag,
-            posY: sample.samplePositionY,
+            posY: sample.position?.y,
           }}
         />
       </DialogContent>

--- a/apps/spu-ui/src/app/_components/store/setup2/sample-item.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/sample-item.tsx
@@ -200,6 +200,7 @@ function SampleDropdownMenu({
         <EditSampleMenuItem
           sample={sample}
           onSubmitCallback={() => setOpen(false)}
+          cardType={cardType}
         />
         <DeleteSampleMenuItem
           sample={sample}
@@ -240,9 +241,11 @@ function SampleDropdownMenu({
 function EditSampleMenuItem({
   sample,
   onSubmitCallback,
+  cardType = "standard",
 }: {
   sample: Sample;
   onSubmitCallback?: () => void;
+  cardType?: (typeof cardModes)[number];
 }) {
   const [open, setOpen] = useState(false);
   const handleOpen = (e: Event) => {
@@ -271,6 +274,7 @@ function EditSampleMenuItem({
         <EditSampleForm
           sample={sample}
           onSubmitCallback={handleSubmitSuccess}
+          cardType={cardType}
         />
       </DialogContent>
     </Dialog>

--- a/apps/spu-ui/src/app/_components/store/setup2/sample-store.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/sample-store.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { usePvData } from "node_modules/@sophys-web/pvws-store/src/lib/hooks";
+import React, { useEffect, useMemo, useState } from "react";
 import { cn } from "@sophys-web/ui";
 import {
   Accordion,
@@ -7,14 +6,31 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@sophys-web/ui/accordion";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@sophys-web/ui/select";
 import { InfoTooltip } from "@sophys-web/widgets/form-components/info-tooltip";
 import { PickCardButtonForm } from "../../plans/setup2-pick-card-by-index-form";
-import { cardColumns, cardIndexOptions, cardRows } from "./constants";
+import {
+  cardCapillaryColumns,
+  cardColumns,
+  cardIndexOptions,
+  cardModes,
+  cardRows,
+} from "./constants";
 import { DeleteSamplesDialog } from "./delete-samples";
 import { OnDemandActions } from "./on-demand-actions-dropdown";
 import { SampleCardState } from "./sample-card-state";
 import { SampleItem } from "./sample-item";
-import { sampleIdFromPosition, useSampleStore } from "./use-sample-store";
+import {
+  sampleIdEncoder,
+  useSampleStore,
+  useSampleStoreCard,
+} from "./use-sample-store";
 
 export function SampleStoreSetup2({ className }: { className?: string }) {
   const { error, parseError, isLoading, isPending } = useSampleStore();
@@ -52,21 +68,58 @@ const reverseSortedColumns = [...cardColumns].sort((a, b) =>
   b.localeCompare(a),
 );
 
+function generateSampleIds(
+  cardIndex: (typeof cardIndexOptions)[number],
+  type: "standard",
+): string[][];
+function generateSampleIds(
+  cardIndex: (typeof cardIndexOptions)[number],
+  type: "capillary",
+): string[];
+function generateSampleIds(
+  cardIndex: (typeof cardIndexOptions)[number],
+  type: SampleCardType,
+): string[][] | string[] {
+  if (type === "capillary") {
+    return cardCapillaryColumns.map((column) =>
+      sampleIdEncoder.parse({
+        card: cardIndex,
+        type: "capillary",
+        position: { column },
+      }),
+    );
+  }
+
+  return cardRows.map((row) =>
+    reverseSortedColumns.map((column) =>
+      sampleIdEncoder.parse({
+        card: cardIndex,
+        type: "standard",
+        position: { row, column },
+      }),
+    ),
+  );
+}
+
 function SampleCardGrid({
   cardIndex,
 }: {
   cardIndex: (typeof cardIndexOptions)[number];
 }) {
-  const { storeData } = useSampleStore();
+  const sampleIds = useMemo(
+    () => generateSampleIds(cardIndex, "standard"),
+    [cardIndex],
+  );
+
   return (
     <div
       className={cn(
-        "grid grid-flow-row justify-items-center gap-2",
+        "grid grid-flow-row justify-items-center gap-1",
         `grid-cols-5`,
         `grid-rows-7`,
       )}
     >
-      {/* fill first row with column headers*/}
+      {/* first row with column headers*/}
       <div className="flex items-center justify-center text-sm font-normal md:text-base" />
       {reverseSortedColumns.map((col) => (
         <div
@@ -76,109 +129,150 @@ function SampleCardGrid({
           {col}
         </div>
       ))}
-      {cardRows.map((row) => (
-        <React.Fragment key={`row-${row}`}>
-          {/* first column is the row id */}
-          <div
-            className="flex items-center justify-center text-sm font-normal md:text-base"
-            key={`header-${row}`}
-          >
-            {row}
-          </div>
-          {/* fill the rest of the row with sample items
-          with the cardColumns sorted in reverse order to match the visual layout of the card 
-          */}
-          {reverseSortedColumns.map((column) => {
-            const sampleId = sampleIdFromPosition({
-              cardIndex,
-              row,
-              column,
-            });
-            // do not show row 6 column D since it is not used in the actual card layout
-            if (row === "6" && column === "D") {
-              return <div key={sampleId} />;
-            }
-            const sample = storeData?.[sampleId];
-            return (
-              <SampleItem key={sampleId} sampleId={sampleId} sample={sample} />
-            );
-          })}
-        </React.Fragment>
-      ))}
+      {sampleIds.map((rowSampleIds, rowIndex) => {
+        const row = cardRows[rowIndex];
+        return (
+          <React.Fragment key={`row-${row}`}>
+            {/* first column for row header */}
+            <div
+              className="flex items-center justify-center text-sm font-normal md:text-base"
+              key={`header-${row}`}
+            >
+              {row}
+            </div>
+            {/* rest of the row with sample items */}
+            {rowSampleIds.map((sampleId) => {
+              // row 6 column D should not be displayed
+              if (row === "6" && sampleId.split("-").includes("D6")) {
+                return <div key={sampleId} />;
+              }
+              return (
+                <SampleItem
+                  key={sampleId}
+                  sampleId={sampleId}
+                  cardType="standard"
+                />
+              );
+            })}
+          </React.Fragment>
+        );
+      })}
     </div>
   );
 }
 
-/**
- * Determines the status of a card based on its name value.
- * @param cardName
- * @returns
- */
-function getCardNameStatus(
-  cardName: string | null | undefined,
-): "CardNotFound" | "NameNotFound" | "Identified" {
-  if (!cardName) {
-    return "CardNotFound";
-  }
-  if (cardName === "Not Identified by Robot") {
-    return "CardNotFound";
-  }
-  if (cardName === "Not Identified by Cam") {
-    return "NameNotFound";
-  }
-  return "Identified";
-}
+function SampleCardCapillary({
+  cardIndex,
+}: {
+  cardIndex: (typeof cardIndexOptions)[number];
+}) {
+  const sampleIds = useMemo(
+    () => generateSampleIds(cardIndex, "capillary"),
+    [cardIndex],
+  );
 
-/**
- * Custom hook to get the name and status of a sample card based on its index.
- * It uses the usePvData hook to subscribe to the corresponding PV for the card name
- * and interprets the status based on the PV value.
- */
-export const useSampleCardName = (
-  cardIndex: (typeof cardIndexOptions)[number],
-) => {
-  const pvName = `SPU:B:YASKAWA01:Card${cardIndex}_RBV`;
-  const pvData = usePvData(pvName);
-  const cardName = pvData?.text;
-  const status = getCardNameStatus(cardName);
-  return {
-    cardName: status === "Identified" ? cardName : undefined,
-    status: status,
-  };
-};
+  return (
+    <div className="mx-1 grid w-80 grid-flow-row grid-cols-11 justify-items-center gap-1">
+      {sampleIds.map((sampleId) => (
+        <div
+          key={`column-${sampleId}`}
+          className="flex w-fit flex-col items-center gap-1"
+        >
+          <SampleItem key={sampleId} sampleId={sampleId} cardType="capillary" />
+          <span className="justify-center text-center text-sm">
+            {sampleId.split("-")[1]} {/* Display the column letter */}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
 
 interface SampleCardAccordionItemProps
   extends React.ComponentProps<typeof AccordionItem> {
   value: (typeof cardIndexOptions)[number];
 }
 
+/**
+ * Defines tow types of sample cards: "grid" and "capillary".
+ * The "grid" type corresponds to the standard card layout with samples arranged in a grid of rows 1-6 and columns D-A.
+ * The "capillary" type corresponds to a different layout that supports 11 samples in vertical capillaries side by side and the samples
+ * do not have row and column positions.
+ */
+type SampleCardType = (typeof cardModes)[number];
+
+function SampleCardItems({
+  cardIndex,
+  type,
+}: {
+  cardIndex: (typeof cardIndexOptions)[number];
+  type: SampleCardType;
+}) {
+  if (type === "capillary") {
+    return <SampleCardCapillary cardIndex={cardIndex} />;
+  }
+  // default to "standard" grid layout if type is not "capillary"
+  return <SampleCardGrid cardIndex={cardIndex} />;
+}
+
+// all sampleIds should contain
 function SampleCardAccordionItem({ ...props }: SampleCardAccordionItemProps) {
   const cardIndex = props.value;
-  const { cardName, status } = useSampleCardName(cardIndex);
+  // const { cardName, status } = useSampleCardName(cardIndex);
+  const [sampleCardType, setSampleCardType] =
+    useState<SampleCardType>("standard");
+
+  const { cardType, cardName, cardStatus } = useSampleStoreCard(cardIndex);
+
+  useEffect(() => {
+    if (cardType) {
+      setSampleCardType(cardType);
+    }
+  }, [cardType]);
 
   return (
-    <AccordionItem className="max-w-60 border-b" {...props}>
+    <AccordionItem className="border-b" {...props}>
       <AccordionTrigger
         className={cn(
           "truncate",
-          status === "CardNotFound" && "text-muted-foreground",
+          cardStatus === "CardNotFound" && "text-muted-foreground",
         )}
       >
         {`Card ${cardIndex}: `}
         <span>
-          {status === "CardNotFound" && "Card not found"}
-          {status === "NameNotFound" && "Not identified"}
-          {status === "Identified" && cardName}
+          {cardStatus === "CardNotFound" && "Card not found"}
+          {cardStatus === "NameNotFound" && "Not identified"}
+          {cardStatus === "Identified" && cardName}
         </span>
       </AccordionTrigger>
       <AccordionContent className="my-2 flex w-full flex-col space-y-2">
-        <PickCardButtonForm
-          index={cardIndex}
-          className="w-full"
-          variant={"outline"}
-          disabled={status === "CardNotFound"}
-        />
-        {status === "CardNotFound" && (
+        <div className="flex flex-row items-center gap-1">
+          <Select
+            disabled={cardType !== undefined}
+            value={sampleCardType}
+            onValueChange={(value) =>
+              setSampleCardType(value as SampleCardType)
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select card type" />
+            </SelectTrigger>
+            <SelectContent>
+              {cardModes.map((mode) => (
+                <SelectItem key={mode} value={mode}>
+                  {mode}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <PickCardButtonForm
+            cardMode={cardType}
+            index={cardIndex}
+            variant={"outline"}
+            disabled={cardStatus === "CardNotFound"}
+          />
+        </div>
+        {cardStatus === "CardNotFound" && (
           <InfoTooltip variant={"destructive"}>
             <p className="w-40 text-sm">
               Card not found. Please run 'Detect Cards' to update the card hotel
@@ -186,7 +280,7 @@ function SampleCardAccordionItem({ ...props }: SampleCardAccordionItemProps) {
             </p>
           </InfoTooltip>
         )}
-        {status === "NameNotFound" && (
+        {cardStatus === "NameNotFound" && (
           <InfoTooltip variant={"subtle"}>
             <p className="w-40 text-sm">
               Card detected but not identified. Please check if the card is
@@ -194,8 +288,8 @@ function SampleCardAccordionItem({ ...props }: SampleCardAccordionItemProps) {
             </p>
           </InfoTooltip>
         )}
-        {status === "Identified" && <span className="text-sm">{cardName}</span>}
-        <SampleCardGrid cardIndex={cardIndex} />
+
+        <SampleCardItems cardIndex={cardIndex} type={sampleCardType} />
       </AccordionContent>
     </AccordionItem>
   );

--- a/apps/spu-ui/src/app/_components/store/setup2/sample-store.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/sample-store.tsx
@@ -266,7 +266,8 @@ function SampleCardAccordionItem({ ...props }: SampleCardAccordionItemProps) {
             </SelectContent>
           </Select>
           <PickCardButtonForm
-            cardMode={cardType}
+            key={`pick-card-${cardIndex}-${sampleCardType}`} // force re-render when sampleCardType changes to reset the form default values
+            cardMode={sampleCardType}
             index={cardIndex}
             variant={"outline"}
             disabled={cardStatus === "CardNotFound"}

--- a/apps/spu-ui/src/app/_components/store/setup2/use-sample-store.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/use-sample-store.tsx
@@ -1,41 +1,292 @@
+import { useMemo } from "react";
 import { z } from "zod";
 import { useStore } from "@sophys-web/api-client/hooks";
-import { cardColumns, cardIndexOptions, cardRows } from "./constants";
+import { usePvData } from "@sophys-web/pvws-store";
+import {
+  cardCapillaryColumns,
+  cardColumns,
+  cardIndexOptions,
+  cardRows,
+  cardSlotRadius,
+  cardTypesCapillary,
+  cardTypesGrid,
+} from "./constants";
 
 const STORE_INSTANCE_NAME = "sampleStoreSetup2";
 
+const validCardIndex = z.enum(cardIndexOptions, {
+  message: "Invalid card index",
+});
+const validCardType = z.enum([cardTypesGrid, cardTypesCapillary], {
+  message: "Invalid card type",
+});
+const validGridRow = z.enum(cardRows, {
+  message: "Invalid grid row",
+});
+const validGridColumn = z.enum(cardColumns, {
+  message: "Invalid grid column",
+});
+const validCapillaryColumn = z.enum(cardCapillaryColumns, {
+  message: "Invalid capillary column",
+});
+
+export const sampleIdRegex = /^card(\d)-([A-Z]\d?)-(standard|capillary)$/;
+
+const sampleIdSchema = z.object({
+  card: validCardIndex,
+  position: z.string().regex(/^[A-Z]\d?$/),
+  type: validCardType,
+});
+
+const sampleIdStringToObject = z.string().transform((id, ctx) => {
+  const match = sampleIdRegex.exec(id);
+  if (!match) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid ID format: ${id}`,
+    });
+    return z.NEVER;
+  }
+  const [_, card, position, type] = match;
+
+  const parsed = sampleIdSchema.safeParse({ card, position, type });
+  if (!parsed.success) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid ID components: ${JSON.stringify(parsed.error.issues)}`,
+    });
+    return z.NEVER;
+  }
+
+  return parsed.data;
+});
+
+const samplePositionGridSchema = z.object({
+  column: validGridColumn,
+  row: validGridRow,
+});
+
+const samplePositionCapillarySchema = z.object({
+  column: validCapillaryColumn,
+});
+
+export const sampleIdDecoder = z.string().transform((id, ctx) => {
+  const parsed = sampleIdStringToObject.safeParse(id);
+  if (!parsed.success) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Invalid sample ID: ${id}`,
+    });
+    return z.NEVER;
+  }
+  const { card, position, type } = parsed.data;
+  if (type === cardTypesGrid) {
+    const [column, row] = position.split("");
+    const positionResult = samplePositionGridSchema.safeParse({ column, row });
+    if (!positionResult.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid grid position in sample ID: ${id}`,
+      });
+      return z.NEVER;
+    }
+    return { card, position: positionResult.data, type };
+  } else {
+    const positionResult = samplePositionCapillarySchema.safeParse({
+      column: position,
+    });
+    if (!positionResult.success) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Invalid capillary position in sample ID: ${id}`,
+      });
+      return z.NEVER;
+    }
+    return { card, position: positionResult.data, type };
+  }
+});
+
+export const sampleIdEncoder = z
+  .object({
+    card: validCardIndex,
+    position: z.union([
+      samplePositionGridSchema,
+      samplePositionCapillarySchema,
+    ]),
+    type: validCardType,
+  })
+  .transform(({ card, position, type }) => {
+    if (type === cardTypesGrid) {
+      const { column, row } = position as z.infer<
+        typeof samplePositionGridSchema
+      >;
+      return `card${card}-${column}${row}-${type}`;
+    } else {
+      const { column } = position as z.infer<
+        typeof samplePositionCapillarySchema
+      >;
+      return `card${card}-${column}-${type}`;
+    }
+  });
+
+/**
+ * The main schema for a sample object, which includes the sample's ID (which encodes its position and type), a sample tag, its position in 2D space, etc.
+ */
 export const sampleSchema = z.object({
   id: z.string(),
   sampleTag: z.string(),
-  row: z.enum(cardRows),
-  column: z.enum(cardColumns),
-  cardIndex: z.enum(cardIndexOptions),
-  samplePositionX: z.coerce.number(),
-  samplePositionY: z.coerce.number(),
-  meta: z.string().optional(),
+  position: z
+    .object({
+      x: z.coerce.number(),
+      y: z.coerce.number(),
+    })
+    .optional(),
+  notes: z.string().optional(),
 });
 
+/**
+ * Instantiates a sample store for sampleSchema data.
+ * @returns A hook that provides access to the sample store, with the data validated against the sampleSchema.
+ */
 export const useSampleStore = () =>
   useStore({
     schema: sampleSchema,
     storeInstanceName: STORE_INSTANCE_NAME,
   });
 
+// Type helpers
+
 export type Sample = z.infer<typeof sampleSchema>;
 export type SampleStore = ReturnType<typeof useSampleStore>["storeData"];
 
-export function sampleIdFromPosition({
-  cardIndex,
-  row,
-  column,
-}: {
-  cardIndex: (typeof cardIndexOptions)[number];
-  row: (typeof cardRows)[number];
-  column: (typeof cardColumns)[number];
-}) {
-  return `${cardIndex}-${row}-${column}`;
+// Helper functions for generating sample IDs based on their position and type
+
+export function isValidCardCoordinates({ x, y }: { x: number; y: number }) {
+  return Math.sqrt(x ** 2 + y ** 2) <= cardSlotRadius;
 }
-export function positionFromSampleId(sampleId: string) {
-  const [cardIndex, row, column] = sampleId.split("-");
-  return { cardIndex, row, column };
+
+export const sampleSchemaValidPosition = sampleSchema.refine(
+  (data) =>
+    data.position &&
+    isValidCardCoordinates({ x: data.position.x, y: data.position.y }),
+  {
+    message: `Sample position must be within a circle of radius ${cardSlotRadius}.`,
+    path: ["position", "x"],
+  },
+);
+
+/**
+ * Determines the status of a card based on its name value.
+ * @param cardName
+ * @returns
+ */
+function getCardNameStatus(
+  cardName: string | null | undefined,
+): "CardNotFound" | "NameNotFound" | "Identified" {
+  if (!cardName) {
+    return "CardNotFound";
+  }
+  if (cardName === "Not Identified by Robot") {
+    return "CardNotFound";
+  }
+  if (cardName === "Not Identified by Cam") {
+    return "NameNotFound";
+  }
+  return "Identified";
 }
+
+type SampleRecord = Record<
+  string,
+  {
+    decodedId: z.infer<typeof sampleIdDecoder>;
+    data: Sample;
+  }
+>;
+
+interface UseSampleStoreCard {
+  cardName: string | undefined;
+  cardStatus: "CardNotFound" | "NameNotFound" | "Identified";
+  samples: SampleRecord;
+  cardType: z.infer<typeof validCardType> | undefined;
+  inconsistentSampleIds: string[];
+}
+
+export const useSampleStoreCard = (
+  cardIndex: (typeof cardIndexOptions)[number],
+): UseSampleStoreCard => {
+  const pvName = `SPU:B:YASKAWA01:Card${cardIndex}_RBV`;
+  const pvData = usePvData(pvName);
+  const cardName = pvData?.text ?? undefined;
+  const status = getCardNameStatus(cardName);
+
+  const { storeData } = useSampleStore();
+
+  const derived = useMemo<
+    Omit<UseSampleStoreCard, "cardName" | "cardStatus" | "clearCardSamples">
+  >(() => {
+    if (!storeData) {
+      return {
+        samples: {},
+        cardType: undefined,
+        inconsistentSampleIds: [],
+      };
+    }
+
+    const samples: SampleRecord = {};
+
+    Object.keys(storeData).forEach((id) => {
+      const parsed = sampleIdDecoder.safeParse(id);
+      const sample = storeData[id];
+
+      if (!parsed.success || parsed.data.card !== cardIndex || !sample) {
+        return;
+      }
+
+      samples[id] = {
+        decodedId: parsed.data,
+        data: sample,
+      };
+    });
+
+    if (Object.keys(samples).length === 0) {
+      return {
+        samples: {},
+        cardType: undefined,
+        inconsistentSampleIds: [],
+      };
+    }
+
+    const types = new Set(Object.values(samples).map((s) => s.decodedId.type));
+    const firstType = types.values().next().value;
+    if (types.size > 1) {
+      const inconsistentSampleIds = Object.values(samples)
+        .filter((s) => s.decodedId.type !== firstType)
+        .map((s) => sampleIdEncoder.parse(s.decodedId));
+      return {
+        samples,
+        cardType: undefined,
+        inconsistentSampleIds,
+      };
+    }
+
+    if (firstType !== "standard" && firstType !== "capillary") {
+      return {
+        samples,
+        cardType: undefined,
+        inconsistentSampleIds: [],
+      };
+    }
+
+    return {
+      samples,
+      cardType: firstType,
+      inconsistentSampleIds: [],
+    };
+  }, [storeData, cardIndex]);
+
+  return {
+    ...derived,
+    cardName: status === "Identified" ? cardName : undefined,
+    cardStatus: status,
+  };
+};

--- a/apps/spu-ui/src/app/_components/store/setup2/use-sample-store.tsx
+++ b/apps/spu-ui/src/app/_components/store/setup2/use-sample-store.tsx
@@ -161,14 +161,20 @@ export type SampleStore = ReturnType<typeof useSampleStore>["storeData"];
 
 // Helper functions for generating sample IDs based on their position and type
 
-export function isValidCardCoordinates({ x, y }: { x: number; y: number }) {
+export function isValidCardCoordinatesGridSlot({
+  x,
+  y,
+}: {
+  x: number;
+  y: number;
+}) {
   return Math.sqrt(x ** 2 + y ** 2) <= cardSlotRadius;
 }
 
 export const sampleSchemaValidPosition = sampleSchema.refine(
   (data) =>
     data.position &&
-    isValidCardCoordinates({ x: data.position.x, y: data.position.y }),
+    isValidCardCoordinatesGridSlot({ x: data.position.x, y: data.position.y }),
   {
     message: `Sample position must be within a circle of radius ${cardSlotRadius}.`,
     path: ["position", "x"],


### PR DESCRIPTION
Changes in setup 2 to support two types of sample cards.

<img width="480" height="653" alt="image" src="https://github.com/user-attachments/assets/510ab4d2-f4db-45db-b05b-3215f065ea07" />
